### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,13 +2,13 @@
 buildifier: latest
 tasks:
   ubuntu_default_compiler:
-    platform: ubuntu1604
+    platform: ubuntu1804
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   ubuntu_default_compiler_manual:
-    platform: ubuntu1604
+    platform: ubuntu1804
     soft_fail: true
     build_targets:
     - "//repositories:libcurl_tls_test"


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.